### PR TITLE
updated readme with examples, addressed two real-world issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,91 @@ MANIFOLD_PRODUCT_ID=YOUR-PRODUCT-ID
 ```
 
 ## Usage
-Once installed and configured, your project/resource variables from Manifold
-will be pulled into your Laravel application as configurations. Your variables
-can be accessed using the `config` helper, using the key as it exists in
-Manifold. For example, a variable stored in your Manifold resource named
-`API_KEY` can be accessed using `config('API_KEY')`.
+Once installed and configured, your project/resource credentials from Manifold
+will be pulled into your Laravel application as configurations. Your credentials
+can be accessed using the `config` helper, using the label of the resource and
+the key of credential, as they exist in Manifold, using dot-notation. For
+example, if you have a Mailgun resource setup with a credential named `API_KEY`,
+it can be accessed using `config('mailgun.API_KEY')` (where `mailgun` is the
+resource's label).
 
-Note that keys are case sensitive. Also note that when variable keys conflict,
-either with each other or with other Laravel configs, the last value with the
-given key will be the one added to the configuration.
+Note that keys are case sensitive. Also note that when configurations conflict
+with other Laravel configs, the Manifold configurations will take priority.
+
+## Aliases
+In some cases, you may wish to use credentials from Manifold within
+configuration files (inside your `/config` directory). The most obvious use case
+would be database credentials that are needed within `/config/database.php`.
+Since you cannot reliably access configurations from within configuration files
+using the `config()` helper, aliases may be defined in your `config/manifold.php`
+file. Aliases can be defined in arrays (as with standard configurations) or
+using dot-notation for array keys. Define the existing config as the key and
+the Manifold credential as the value. For example, pulling a PostgreSQL password
+from a custom PostgreSQL service in Manifold could look like this:
+`'database.connections.pgsql.password' => 'custom-pgsql.DB_PASSWORD'`. This will
+pull the `DB_PASSWORD` credential from the `custom-pgsql` resource and assign
+its value to `database.connections.pgsql.password`, so there is no need to
+manipulate your existing `config/database.php` file. If the given
+resource/credential combination does not exist, whatever was already defined in
+`config/database.php` will be used.
+
+## Examples
+1. You have a project in Manifold with an ID of `01234567890123456789012345678`.
+You want your Mailgun API key available in a controller method. Your Mailgun
+resource is named `mailgun` and the API key credential is `API_KEY`.
+
+Add the following to `.env`
+```
+MANIFOLD_API_TOKEN=0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789AB
+MANIFOLD_PROJECT_ID=01234567890123456789012345678
+```
+
+In your controller's php file:
+```
+class MyController extends Controller{
+    public function process_mail(){
+
+        $mailgun_key = config('mailgun.API_KEY');
+
+        //mail processing logic here
+    }
+}
+```
+
+2. You have a project in Manifold with an ID of `01234567890123456789012345678`.
+You want your PostgreSQL credentials from your custom service stored in Manifold.
+Your custom service is named `custom-pgsql` and the PostgreSQL credential keys
+are `DB_HOST`, `DB_DATABASE`, `DB_USERNAME`, and `DB_PASSWORD`.
+
+Add the following to `.env`
+```
+MANIFOLD_API_TOKEN=0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789AB
+MANIFOLD_PROJECT_ID=01234567890123456789012345678
+```
+
+In your `config/manifold.php`:
+```
+return [
+    'token' => env('MANIFOLD_API_TOKEN', null),
+    'resource_id' => env('MANIFOLD_RESOURCE_ID', null),
+    'project_id' => env('MANIFOLD_PROJECT_ID', null),
+    'product_id' => env('MANIFOLD_PRODUCT_ID', null),
+    'aliases' => [
+        /*
+            note that while you can mix and match array syntax and dot-notation
+            it's best to use one or the other, this merely illustrates that both
+            are possible
+        */
+        'database.connections.pgsql.password' => 'custom-pgsql.DB_PASSWORD',
+        'database' => [
+            'connections' => [
+                'pgsql' => [
+                    'host' => 'custom-pgsql.DB_HOST',
+                    'database' => 'custom-pgsql.DB_DATABASE',
+                    'username' => 'custom-pgsql.DB_USERNAME',
+                ]
+            ]
+        ]
+    ],
+];
+```

--- a/src/Core.php
+++ b/src/Core.php
@@ -33,6 +33,16 @@ class Core
         collect($configs)->each(function($value, $key){
             config([$key => $value]);
         });
+
+        $aliases = config('manifold.aliases');
+        if(!empty($aliases)){
+            $array_dots = collect(array_dot($aliases));
+            $array_dots->each(function($value, $key){
+                if(config($value))
+                    config([$key => config($value)]);
+            });
+        }
+
         return $configs;
     }
 

--- a/src/config/manifold.php
+++ b/src/config/manifold.php
@@ -5,4 +5,7 @@ return [
     'resource_id' => env('MANIFOLD_RESOURCE_ID', null),
     'project_id' => env('MANIFOLD_PROJECT_ID', null),
     'product_id' => env('MANIFOLD_PRODUCT_ID', null),
+    'aliases' => [
+        
+    ],
 ];

--- a/src/manifoldServiceProvider.php
+++ b/src/manifoldServiceProvider.php
@@ -33,10 +33,7 @@ class manifoldServiceProvider extends ServiceProvider
         }
 
         $core = new Core;
-        //normal boot
         $core->load_configs();
-        //forcing reload of fresh data
-        // $core->refresh();
 
     }
     /**


### PR DESCRIPTION
Credential key names can be ambiguous, so they are now namespaced in Laravel with the resource's label. The config helper is not reliable inside config files, so you cannot reference a config variable defined by Manifold inside other config files. To address this, an aliases section was added to the manifold.php config file so that you can define what existing configs should be overwritten by which Manifold configs -- main use case would be for DB creds. See readme