### PR TITLE
move from referencing projects by ID to by label

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ follows: `MANIFOLD_API_TOKEN=YOUR-TOKEN-HERE`
 respective IDs in your `.env` file.  
 ```
 MANIFOLD_RESOURCE_ID=YOUR-RESOURCE-ID
-MANIFOLD_PROJECT_ID=YOUR-PROJECT-ID
+MANIFOLD_PROJECT=YOUR-PROJECT-LABEL
 MANIFOLD_PRODUCT_ID=YOUR-PRODUCT-ID
 ```
 
@@ -68,14 +68,14 @@ resource/credential combination does not exist, whatever was already defined in
 `config/database.php` will be used.
 
 ## Examples
-1. You have a project in Manifold with an ID of `01234567890123456789012345678`.
+1. You have a project in Manifold with an label of `my-project`.
 You want your Mailgun API key available in a controller method. Your Mailgun
 resource is named `mailgun` and the API key credential is `API_KEY`.
 
 Add the following to `.env`
 ```
 MANIFOLD_API_TOKEN=0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789AB
-MANIFOLD_PROJECT_ID=01234567890123456789012345678
+MANIFOLD_PROJECT=my-project
 ```
 
 In your controller's php file:
@@ -90,7 +90,7 @@ class MyController extends Controller{
 }
 ```
 
-2. You have a project in Manifold with an ID of `01234567890123456789012345678`.
+2. You have a project in Manifold with a label of `my-project`.
 You want your PostgreSQL credentials from your custom service stored in Manifold.
 Your custom service is named `custom-pgsql` and the PostgreSQL credential keys
 are `DB_HOST`, `DB_DATABASE`, `DB_USERNAME`, and `DB_PASSWORD`.
@@ -98,7 +98,7 @@ are `DB_HOST`, `DB_DATABASE`, `DB_USERNAME`, and `DB_PASSWORD`.
 Add the following to `.env`
 ```
 MANIFOLD_API_TOKEN=0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789AB
-MANIFOLD_PROJECT_ID=01234567890123456789012345678
+MANIFOLD_PROJECT=my-project
 ```
 
 In your `config/manifold.php`:
@@ -106,7 +106,7 @@ In your `config/manifold.php`:
 return [
     'token' => env('MANIFOLD_API_TOKEN', null),
     'resource_id' => env('MANIFOLD_RESOURCE_ID', null),
-    'project_id' => env('MANIFOLD_PROJECT_ID', null),
+    'project' => env('MANIFOLD_PROJECT', null),
     'product_id' => env('MANIFOLD_PRODUCT_ID', null),
     'aliases' => [
         /*

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ resource/credential combination does not exist, whatever was already defined in
 `config/database.php` will be used.
 
 ## Examples
-1. You have a project in Manifold with an label of `my-project`.
+1. You have a project in Manifold with a label of `my-project`.
 You want your Mailgun API key available in a controller method. Your Mailgun
 resource is named `mailgun` and the API key credential is `API_KEY`.
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -13,7 +13,7 @@ class Core
 
     static $key_token       = 'manifold.token';
     static $key_product     = 'manifold.product_id';
-    static $key_project     = 'manifold.project_id';
+    static $key_project     = 'manifold.project';
     static $key_resource    = 'manifold.resource_id';
 
     static $DEBUG           = false;
@@ -139,7 +139,15 @@ class Core
                 return 'product_id=' . $this->product;
                 break;
             case self::$PROJECT:
-                return 'project_id=' . $this->project;
+                $projects = json_decode($this->api->server_request('projects?label=' . $this->project));
+                if(count($projects) > 1 || count($projects) < 1){
+                    return null;
+                }else{
+                    if(isset($projects[0]->id)){
+                        return 'project_id=' . $projects[0]->id;
+                    }
+                }
+                return null;
                 break;
             case self::$RESOURCE:
                 return null;

--- a/src/config/manifold.php
+++ b/src/config/manifold.php
@@ -3,9 +3,9 @@
 return [
     'token' => env('MANIFOLD_API_TOKEN', null),
     'resource_id' => env('MANIFOLD_RESOURCE_ID', null),
-    'project_id' => env('MANIFOLD_PROJECT_ID', null),
+    'project' => env('MANIFOLD_PROJECT', null),
     'product_id' => env('MANIFOLD_PRODUCT_ID', null),
     'aliases' => [
-        
+
     ],
 ];

--- a/tests/CoreTest.php
+++ b/tests/CoreTest.php
@@ -78,7 +78,7 @@ class CoreTest extends TestCase
         $this->assertEquals($this->core->query_string(), 'product_id=' . $this->core->product);
 
         $this->core->resource_level = Core::$PROJECT;
-        $this->assertEquals($this->core->query_string(), 'project_id=' . $this->core->project);
+        $this->assertNotNull($this->core->query_string());
 
         $this->core->resource_level = Core::$RESOURCE;
         $this->assertNull($this->core->query_string());


### PR DESCRIPTION
Addresses #8 - Projects will be referenced by label instead of by ID.
This changes a couple of user facing references, namely the manifold config file and the env variable.

The config in `config/manifold.php` has changed from `project_id` to `project`.
The env variable has changed from `MANIFOLD_PROJECT_ID` to `MANIFOLD_PROJECT`

If you already have a test application you'll want to either delete your `config/manifold.php` file and rerun `vendor:publish` (if you haven't made any customizations) or simply update your config file (and `.env` of course) with the changes above (also, you can review `src/config/manifold.php` in the project folder to review the changes.

One important thing to note: it appears as though the `resources` API endpoint does not support searching by project label. This means when a user supplies a project label, we actually make two requests to Manifold, one to `/projects?label=xxxxxx` and one to `/resources?project_id=1234567890a`. Not a huge deal but it will take longer to fetch credentials this way. Also if the user doesn't supply a project label at all, there is no additional request. If the label does not match any project, all configs will be returned as if the user had provided no project at all.