### PR TITLE
add ability to allow users to pass closures for alias values

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,51 @@ return [
     ],
 ];
 ```
+
+3. You have a project in Manifold with a label of `my-project`.
+You want your MySQL credentials from your JAWS stored in Manifold.
+Your JAWS service is named `jaws-mysql` and the connection credentials are in
+URL syntax as `JAWSDB_URL`. The URL syntax does not work with Laravel out of the
+box and must be parsed. For this you can pass a closure as the value of an
+alias. The closure receives no parameters, but all configs are loaded so you can
+access and Manifold stored credentials and manipulate them as necessary.
+
+Add the following to `.env`
+```
+MANIFOLD_API_TOKEN=0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789AB
+MANIFOLD_PROJECT=my-project
+```
+
+In your `config/manifold.php`:
+```
+return [
+    'token' => env('MANIFOLD_API_TOKEN', null),
+    'resource_id' => env('MANIFOLD_RESOURCE_ID', null),
+    'project' => env('MANIFOLD_PROJECT', null),
+    'product_id' => env('MANIFOLD_PRODUCT_ID', null),
+    'aliases' => [
+        'database' => [
+            'connections' => [
+                'mysql' => [
+                    'host' => function(){
+                        $url = parse_url(config('custom-service.jaws'));
+                        return $url['host'];
+                    },
+                    'password' => function(){
+                        $url = parse_url(config('custom-service.jaws'));
+                        return $url['pass'];
+                    },
+                    'username' => function(){
+                        $url = parse_url(config('custom-service.jaws'));
+                        return $url['user'];
+                    },
+                    'database' => function(){
+                        $url = parse_url(config('custom-service.jaws'));
+                        return substr($url["path"], 1);
+                    }
+                ]
+            ]
+        ]
+    ],
+];
+```

--- a/src/Core.php
+++ b/src/Core.php
@@ -38,8 +38,14 @@ class Core
         if(!empty($aliases)){
             $array_dots = collect(array_dot($aliases));
             $array_dots->each(function($value, $key){
-                if(config($value))
+                if(is_callable($value)){
+                    $call_response = $value();
+                    if($call_response){
+                        config([$key => $call_response]);
+                    }
+                }elseif(is_string($value) && config($value)){
                     config([$key => config($value)]);
+                }
             });
         }
 


### PR DESCRIPTION
Had a discussion with @PLaRoche that lead to an idea. Sometimes credentials are not stored in a way you're going to use them, the best example being JAWS storing MySQL credentials as a single connecting string as opposed to four separate variables. Laravel doesn't use these connection strings out of the box, so they need to be parsed.

So I made a quick change that will now allow users to pass a closure as an alias value, the results of the closure will then be treated as a string and will be assigned to the config like normal. This closure does not receive and parameters, but it does have access to all of the existing configs.

A pretty quick change that, based on my conversation with Patrick, could be pretty useful to users.