### PR TITLE
allow non-truthy values to be assigned to configs in aliases functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,7 @@ from a custom PostgreSQL service in Manifold could look like this:
 `'database.connections.pgsql.password' => 'custom-pgsql.DB_PASSWORD'`. This will
 pull the `DB_PASSWORD` credential from the `custom-pgsql` resource and assign
 its value to `database.connections.pgsql.password`, so there is no need to
-manipulate your existing `config/database.php` file. If the given
-resource/credential combination does not exist, whatever was already defined in
-`config/database.php` will be used.
+manipulate your existing `config/database.php` file. 
 
 ## Examples
 1. You have a project in Manifold with a label of `my-project`.

--- a/src/Core.php
+++ b/src/Core.php
@@ -38,12 +38,11 @@ class Core
         if(!empty($aliases)){
             $array_dots = collect(array_dot($aliases));
             $array_dots->each(function($value, $key){
+                //Basically just stopped checking if the value is truthy because
+                //maybe they want false/null/0/""
                 if(is_callable($value)){
-                    $call_response = $value();
-                    if($call_response){
-                        config([$key => $call_response]);
-                    }
-                }elseif(is_string($value) && config($value)){
+                    config([$key => $value()]);
+                }elseif(is_string($value)){
                     config([$key => config($value)]);
                 }
             });


### PR DESCRIPTION
Addresses #13 to allow non-truthy values to be assigned to configurations in the aliases functionality in `Core.php`