### PR TITLE
Safer failing for negative API responses

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -97,7 +97,11 @@ class Core
                 $configs = [];
                 $resources = $this->api->resources($this->query_string());
                 $resources->each(function($resource) use(&$configs){
-                    $configs = array_merge($configs, $this->api->load_resource($resource));
+                    $api_loaded_resource = $this->api->load_resource($resource);
+                    
+                    if(is_array($api_loaded_resource)){
+                        $configs = array_merge($configs, $api_loaded_resource);
+                    }
                 });
                 return $configs;
                 break;

--- a/src/Core.php
+++ b/src/Core.php
@@ -145,7 +145,7 @@ class Core
                 break;
             case self::$PROJECT:
                 $projects = json_decode($this->api->server_request('projects?label=' . $this->project));
-                if(count($projects) > 1 || count($projects) < 1){
+                if(!is_array($projects) || count($projects) !== 1){
                     return null;
                 }else{
                     if(isset($projects[0]->id)){


### PR DESCRIPTION
Addressing issues #21 & #22. Provides more sanity checks on API response object, instead of assuming they will be what is expected. Specifically:
* Test the results of loading an API resource before trying to merge it into the configs array (`src/Core.php`, `get_fresh_data()`)
* Test prased API response format as array being passing it to `count()` (`src/Core.php`, `query_string()`)